### PR TITLE
Modify Step to accept optional id property

### DIFF
--- a/src/step.ts
+++ b/src/step.ts
@@ -122,6 +122,7 @@ export interface Step {
   action: Action
   estimate?: Estimate
   execution?: Execution
+  id?: string
 }
 
 export interface SwapStep {


### PR DESCRIPTION
We currently have two "Step-ish" types in the front end: `Step` and  `TransferStep`. 
`TransferStep` is like `Step`but adds an optional `id` property we use in Xpollinate and Lifi. In both Apps we need it to store and identify Routes.

We could simplify the frontend and reduce confusion by adding an optional id to `Step` and removing `TransferStep`.