### PR TITLE
feat(Status): add CHAIN_SWITCH_REQUIRED status

### DIFF
--- a/src/step.ts
+++ b/src/step.ts
@@ -51,6 +51,7 @@ export interface Estimate {
 export type Status =
   | 'NOT_STARTED'
   | 'ACTION_REQUIRED'
+  | 'CHAIN_SWITCH_REQUIRED'
   | 'PENDING'
   | 'FAILED'
   | 'DONE'


### PR DESCRIPTION
This status is needed to indicate that the SDK caller needs to perform a chain switch to proceed with the execution