### PR TITLE
fix: remove connections endpoint

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -171,5 +171,5 @@ export declare class LifiAPI {
 
   getStatus(request: GetStatusRequest): Promise<StatusResponse>
 
-  getConnections(request: ConnectionsRequest): Promise<ConnectionsResponse>
+  // getConnections(request: ConnectionsRequest): Promise<ConnectionsResponse>
 }


### PR DESCRIPTION
Until we decided what to do with the /connections endpoint we remove it from the types not not block deployments
