### PR TITLE
feat: add toToken to Execution

### DIFF
--- a/src/step.ts
+++ b/src/step.ts
@@ -87,6 +87,7 @@ export interface Execution {
   process: Array<Process>
   fromAmount?: string
   toAmount?: string
+  toToken?: Token
 }
 
 export const emptyExecution: Execution = {


### PR DESCRIPTION
It can be that the received token changes due to failures in the destination swap. To be able to show the received token we need to store it in the execution object.
