### PR TITLE
fix: set correct harmony RPC

### DIFF
--- a/src/chains.ts
+++ b/src/chains.ts
@@ -350,7 +350,7 @@ export const supportedChains: Array<Chain> = [
         symbol: 'ONE',
         decimals: 18,
       },
-      rpcUrls: ['https://api.harmony.one'],
+      rpcUrls: ['https://api.s0.t.hmny.io'],
     },
   },
 


### PR DESCRIPTION
This is the correct RPC according to their documentation: https://docs.harmony.one/home/developers/sdk/web3#setup-web3js-with-moonbeam
The testnet already has the correct RPC set