### PR TITLE
fix: fix decimals of WETH on Optimism

### DIFF
--- a/src/coins.ts
+++ b/src/coins.ts
@@ -735,7 +735,7 @@ const basicCoins: BasicCoin[] = [
       },
       [ChainId.OPT]: {
         address: '0x4200000000000000000000000000000000000006',
-        decimals: 8,
+        decimals: 18,
       },
       [ChainId.MOR]: {
         address: '0x639a647fbe20b6c8ac19e48e2de44ea792c62c5c',


### PR DESCRIPTION
It has 18 decimals, not 8: https://optimistic.etherscan.io/token/0x4200000000000000000000000000000000000006
