### PR TITLE
feat: added required types for LF-672

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -5,6 +5,8 @@ import {
   ExchangeDefinition,
   Step,
   Token,
+  ExchangeTools,
+  BridgeTool,
 } from '.'
 
 export type Order = 'BEST_VALUE' | 'BEST_FEE' | 'BEST_FEE_GAS' // FAST, LESS_INTERACTIONS, SECURITY, ....
@@ -161,6 +163,20 @@ export interface ChainsResponse {
   chains: Chain[]
 }
 
+export type ExternalExchange = {
+  tool: ExchangeTools
+  chains: number[]
+}
+export type ExternalBridge = {
+  tool: BridgeTool
+  chains: number[]
+}
+
+export type ToolsResponse = {
+  exchanges: ExternalExchange[]
+  bridges: ExternalBridge[]
+}
+
 export type StatusMessage = 'NOT_FOUND' | 'PENDING' | 'DONE' | 'FAILED'
 
 export declare class LifiAPI {
@@ -179,6 +195,8 @@ export declare class LifiAPI {
   getQuote(request: QuoteRequest): Promise<Step>
 
   getStatus(request: GetStatusRequest): Promise<StatusResponse>
+
+  getTools(): Promise<ToolsResponse>
 
   getChains(): ChainsResponse
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,9 +5,9 @@ import {
   ExchangeDefinition,
   Step,
   Token,
-  ExchangeTools,
-  BridgeTool,
 } from '.'
+import { Bridge } from './bridges'
+import { Exchange, ExchangeAggregator } from './exchanges'
 
 export type Order = 'BEST_VALUE' | 'BEST_FEE' | 'BEST_FEE_GAS' // FAST, LESS_INTERACTIONS, SECURITY, ....
 
@@ -163,19 +163,9 @@ export interface ChainsResponse {
   chains: Chain[]
 }
 
-export type ExternalExchange = {
-  tool: ExchangeTools
-  chains: number[]
-}
-export type ExternalBridge = {
-  tool: BridgeTool
-  fromChains: number[]
-  toChains: number[]
-}
-
 export type ToolsResponse = {
-  exchanges: ExternalExchange[]
-  bridges: ExternalBridge[]
+  exchanges: Pick<Exchange, 'key' | 'name'>[]
+  bridges: Pick<Bridge, 'key' | 'name'>[]
 }
 
 export type StatusMessage = 'NOT_FOUND' | 'PENDING' | 'DONE' | 'FAILED'
@@ -197,7 +187,7 @@ export declare class LifiAPI {
 
   getStatus(request: GetStatusRequest): Promise<StatusResponse>
 
-  getTools(): Promise<ToolsResponse>
+  getTools(): ToolsResponse
 
   getChains(): ChainsResponse
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -164,8 +164,8 @@ export interface ChainsResponse {
 }
 
 export type ToolsResponse = {
-  exchanges: Pick<ExchangeDefinition, 'tool'>[]
-  bridges: Pick<BridgeDefinition, 'tool'>[]
+  exchanges: Pick<Exchange | ExchangeAggregator, 'key' | 'name' | 'logoURI'>[]
+  bridges: Pick<Bridge, 'key' | 'name' | 'logoURI'>[]
 }
 
 export type StatusMessage = 'NOT_FOUND' | 'PENDING' | 'DONE' | 'FAILED'

--- a/src/api.ts
+++ b/src/api.ts
@@ -169,7 +169,8 @@ export type ExternalExchange = {
 }
 export type ExternalBridge = {
   tool: BridgeTool
-  chains: number[]
+  fromChains: number[]
+  toChains: number[]
 }
 
 export type ToolsResponse = {

--- a/src/api.ts
+++ b/src/api.ts
@@ -163,6 +163,10 @@ export interface ChainsResponse {
   chains: Chain[]
 }
 
+export interface ToolsRequest {
+  chains?: ChainId[]
+}
+
 export type ToolsResponse = {
   exchanges: Pick<Exchange | ExchangeAggregator, 'key' | 'name' | 'logoURI'>[]
   bridges: Pick<Bridge, 'key' | 'name' | 'logoURI'>[]
@@ -187,7 +191,7 @@ export declare class LifiAPI {
 
   getStatus(request: GetStatusRequest): Promise<StatusResponse>
 
-  getTools(): ToolsResponse
+  getTools(request: ToolsRequest): ToolsResponse
 
   getChains(): ChainsResponse
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -164,8 +164,8 @@ export interface ChainsResponse {
 }
 
 export type ToolsResponse = {
-  exchanges: Pick<Exchange, 'key' | 'name'>[]
-  bridges: Pick<Bridge, 'key' | 'name'>[]
+  exchanges: Pick<ExchangeDefinition, 'tool'>[]
+  bridges: Pick<BridgeDefinition, 'tool'>[]
 }
 
 export type StatusMessage = 'NOT_FOUND' | 'PENDING' | 'DONE' | 'FAILED'


### PR DESCRIPTION
Even though the suggested types were 
```typescript
type ToolsResponse = {
  exchanges: Exchange[]
  bridges: Bridge[]
}

type Exchange = {
  tool: ExchangeTools
  chains: number[]
}
```

I have renamed them to 

```typescript
export type ExternalExchange = {
  tool: ExchangeTools
  chains: number[]
}
export type ExternalBridge = {
  tool: BridgeTool
  chains: number[]
}
```
to avoid collision with the already declared types `Exchange` and `Bridge`.