### PR TITLE
feat: add wrapped gas for ARBT

### DIFF
--- a/src/coins.ts
+++ b/src/coins.ts
@@ -1274,6 +1274,17 @@ export const wrappedTokens: { [ChainId: string]: Token } = {
     name: 'WRAPPED ONE',
     logoURI: 'https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/WONE.png',
   },
+  [ChainId.ARBT]: {
+    // https://testnet.arbiscan.io/token/0x207ed1742cc0bebd03e50e855d3a14e41f93a461
+    address: '0x207ed1742cc0bebd03e50e855d3a14e41f93a461',
+    symbol: 'WETH',
+    decimals: 18,
+    chainId: ChainId.ARBT,
+    coinKey: CoinKey.WETH,
+    name: 'WETH',
+    logoURI:
+      'https://zapper.fi/images/networks/ethereum/0x0000000000000000000000000000000000000000.png',
+  },
 }
 
 export const findDefaultCoin = (coinKey: CoinKey): Coin => {

--- a/src/coins.ts
+++ b/src/coins.ts
@@ -1275,8 +1275,8 @@ export const wrappedTokens: { [ChainId: string]: Token } = {
     logoURI: 'https://d1xrz6ki9z98vb.cloudfront.net/venomswap/tokens/WONE.png',
   },
   [ChainId.ARBT]: {
-    // https://testnet.arbiscan.io/token/0x207ed1742cc0bebd03e50e855d3a14e41f93a461
-    address: '0x207ed1742cc0bebd03e50e855d3a14e41f93a461',
+    // https://testnet.arbiscan.io/token/0xB47e6A5f8b33b3F17603C83a0535A9dcD7E32681
+    address: '0xB47e6A5f8b33b3F17603C83a0535A9dcD7E32681',
     symbol: 'WETH',
     decimals: 18,
     chainId: ChainId.ARBT,


### PR DESCRIPTION
We use ARB testnet for our arbitrum bridge tests, we need to find the wrapped gas token for it.
