### PR TITLE
fix: removed unused NOT_AVAILABLE status

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -156,8 +156,6 @@ const _StatusMessage = [
   // The transaction was not found -- likely not mined yet
   'NOT_FOUND',
   // A third party service is not available
-  'NOT_AVAILABLE',
-  // The given transaction information is invalid
   'INVALID',
   // The transfer is pending
   'PENDING',


### PR DESCRIPTION
In the original planning, NOT_AVAILABLE was a status on its own.
In the current implementation every "not available" scenario is handled as a "PENDING" status.
