### PR TITLE
fix: adjust Arbitrum One name

### DIFF
--- a/src/bridges.ts
+++ b/src/bridges.ts
@@ -110,7 +110,7 @@ export const supportedBridges: Array<Bridge> = [
   },
   {
     key: BridgeTool.arbitrum,
-    name: 'Arbitrum One Bridge',
+    name: 'Arbitrum Bridge',
     logoURI:
       'https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/bridges/arbitrum.png',
     bridgeUrl: 'https://bridge.arbitrum.io/',

--- a/src/chains/supported.chains.ts
+++ b/src/chains/supported.chains.ts
@@ -221,11 +221,11 @@ export const supportedEVMChains: EVMChain[] = [
       rpcUrls: ['https://api.avax.network/ext/bc/C/rpc'],
     },
   },
-  // 42161 - Arbitrum One
+  // 42161 - Arbitrum
   {
     key: ChainKey.ARB,
     chainType: ChainType.EVM,
-    name: 'Arbitrum One',
+    name: 'Arbitrum',
     coin: CoinKey.ETH,
     id: 42161,
     mainnet: true,
@@ -239,7 +239,7 @@ export const supportedEVMChains: EVMChain[] = [
     metamask: {
       chainId: prefixChainId(42161),
       blockExplorerUrls: ['https://arbiscan.io/'],
-      chainName: 'Arbitrum One',
+      chainName: 'Arbitrum',
       nativeCurrency: {
         name: 'AETH',
         symbol: 'AETH',

--- a/src/exchanges.ts
+++ b/src/exchanges.ts
@@ -556,7 +556,7 @@ export const supportedExchanges: Array<Exchange> = [
     ],
   },
 
-  // 42161 - Arbitrum One
+  // 42161 - Arbitrum
   {
     key: 'sushiswap-arb',
     name: 'SushiSwap',


### PR DESCRIPTION
We agreed to rename `Arbitrum One` and `Arbitrum One Bridge` to `Arbitrum` and `Arbitrum Bridge`.