### PR TITLE
fix: update solana supported chains to include network information

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 Types for the LI.FI stack.
 
-### Summary
+## Summary
 
 This package contains all common types for the [LI.FI SDK](https://github.com/lifinance/sdk).
 Learn more about LI.FI on (https://li.fi).
 
 Check out the [Changelog](./CHANGELOG.md) to see what changed in the last releases.
 
-### Install dependencies
+## Install dependencies
 
 Install dependencies with yarn:
 
@@ -23,6 +23,17 @@ or
 npm install --save @lifi/types
 ```
 
-### Summary
+## How to make a release
+
+1. PR with changes
+2. Merge PR into main
+3. Checkout main
+4. `git pull`
+5. `yarn release`
+6. Make sure everything looks good (e.g. in CHANGELOG.md)
+7. `git push --follow-tags`
+8. Done
+
+## Summary
 
 This package contains type definitions for LI.FI projects (https://github.com/lifinance).

--- a/src/chains/SolanaChain.ts
+++ b/src/chains/SolanaChain.ts
@@ -1,3 +1,8 @@
 import { _Chain } from './Chain'
+import { AddEthereumChainParameter } from './EVMChain'
 
-export type SolanaChain = _Chain
+export interface SolanaChain extends _Chain {
+  tokenlistUrl?: string
+  metamask: AddEthereumChainParameter
+  multicallAddress?: string
+}

--- a/src/chains/chain.utils.ts
+++ b/src/chains/chain.utils.ts
@@ -8,6 +8,7 @@ const supportedChains: Chain[] = [
   // This will be added in the future
   // ...supportedSolanaChains,
   ...supportedEVMChains,
+  ...supportedSolanaChains,
 ]
 
 export const getChainByKey = (chainKey: ChainKey): Chain => {

--- a/src/chains/supported.chains.ts
+++ b/src/chains/supported.chains.ts
@@ -1354,6 +1354,21 @@ export const supportedSolanaChains: SolanaChain[] = [
     logoURI:
       'https://raw.githubusercontent.com/lifinance/types/main/src/assets/icons/chains/solana.svg',
     faucetUrls: ['https://stakely.io/faucet/solana-sol'],
+    metamask: {
+      chainId: ChainId.SOL.toString(),
+      blockExplorerUrls: [
+        'https://explorer.solana.com/',
+        'https://solscan.io/',
+        'https://solana.fm/',
+      ],
+      chainName: 'Solana',
+      nativeCurrency: {
+        name: 'SOL',
+        symbol: 'SOL',
+        decimals: 9,
+      },
+      rpcUrls: ['https://api.mainnet-beta.solana.com'],
+    },
   },
 ]
 

--- a/src/chains/supported.chains.ts
+++ b/src/chains/supported.chains.ts
@@ -1375,4 +1375,4 @@ export const supportedSolanaChains: SolanaChain[] = [
 // This assignment is required to avoid breaking
 // changes with the new non EVM support types release
 // This will be removed in the future
-export const supportedChains = supportedEVMChains
+export const supportedChains = [...supportedEVMChains, ...supportedSolanaChains]


### PR DESCRIPTION
## About
Added metamask (network) information to Solana chain. Thus the SolanaChain type and EVMChain type should be the same. However, merging them into a common chain object can be breaking and should be done in a separate task. 