### PR TITLE
feat: deprecate the possibilities endpoint

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -99,6 +99,10 @@ export interface RoutesResponse {
 
 export type PossibilityTopic = 'chains' | 'tokens' | 'bridges' | 'exchanges'
 
+/**
+ * We don't want to support this endpoint anymore in the future. /chains, /tools, /connections, and /tokens should be used instead
+ * @deprecated
+ */
 export interface PossibilitiesRequest {
   chains?: number[] // (default: [all]) // eg. [1, 56, 100]
   bridges?: AllowDenyPrefer
@@ -106,6 +110,10 @@ export interface PossibilitiesRequest {
   include?: PossibilityTopic[]
 }
 
+/**
+ * Should not be accessed via the types package anymore
+ * @deprecated
+ */
 export interface PossibilitiesResponse {
   chains?: Chain[]
   tokens?: Token[]

--- a/src/base.ts
+++ b/src/base.ts
@@ -216,6 +216,10 @@ export interface ExchangeDefinition {
   chains: number[]
 }
 
+/**
+ * Should not be accessed via the types package anymore
+ * @deprecated
+ */
 export interface BridgeDefinition {
   tool: BridgeTool
   fromChainId: number


### PR DESCRIPTION
We don't want to support this endpoint anymore in the future. /chains, /tools, /connections, and /tokens should be used instead