### PR TITLE
fix: remove unused and failing install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "import": "./dist/index.js"
   },
   "scripts": {
-    "install": "node -e \"if (!require('fs').existsSync('./dist')){process.exit(1)}\" || npm run build",
     "watch": "tsc -w -p ./tsconfig.json",
     "build": "node tools/cleanup types && tsc -p ./tsconfig.json && tsc -p ./tsconfig.cjs.json",
     "clean": "node tools/cleanup",


### PR DESCRIPTION
The `install` script was previously used when using uncompiled types locally. The script is not OS independent and not need when loading the package from npm.