### PR TITLE
fix(chains): update zkEVM rpc

### DIFF
--- a/src/chains/supported.chains.ts
+++ b/src/chains/supported.chains.ts
@@ -911,7 +911,7 @@ export const supportedEVMChains: EVMChain[] = [
         symbol: 'ETH',
         decimals: 18,
       },
-      rpcUrls: ['https://polygon-rpc.com/zkevm'],
+      rpcUrls: ['https://zkevm-rpc.com'],
     },
   },
 


### PR DESCRIPTION
This is the official RPC mentioned here: https://zkevm.polygon.technology/docs/develop#connecting-to-zkevm
Also it's the only green one on chainlist
![image](https://github.com/lifinance/types/assets/8833906/0cdf9c2a-a606-4aab-8d2d-4f6bc838ffe6)
