### PR TITLE
fix: fix zksync block explorer url

### DIFF
--- a/src/chains/supported.chains.ts
+++ b/src/chains/supported.chains.ts
@@ -880,7 +880,7 @@ export const supportedEVMChains: EVMChain[] = [
 
     metamask: {
       chainId: prefixChainId(324),
-      blockExplorerUrls: ['https://zkscan.io/'],
+      blockExplorerUrls: ['https://explorer.zksync.io/'],
       chainName: 'zkSync Era Mainnet',
       nativeCurrency: {
         name: 'ETH',


### PR DESCRIPTION
The old url points to some weird shit explorer that doesn't work