### PR TITLE
feat: add chainRequest for the /chains endpoint

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -3,6 +3,7 @@ import {
   BridgeDefinition,
   Chain,
   ChainId,
+  ChainType,
   ExchangeDefinition,
   LifiStep,
   Token,
@@ -240,6 +241,7 @@ export interface ConnectionsRequest extends ToolConfiguration {
   fromToken?: string
   toChain?: number | string
   toToken?: string
+  chainType?: ChainType
 }
 
 export interface Connection {
@@ -369,12 +371,17 @@ export interface ChainsResponse {
   chains: ExtendedChain[]
 }
 
+export interface ChainsRequest {
+  chainType?: ChainType
+}
+
 export interface ToolsRequest {
   chains?: ChainId[]
 }
 
 export type TokensRequest = {
   chains?: ChainId[]
+  chainType?: ChainType
 }
 
 export type TokensResponse = {


### PR DESCRIPTION
https://lifi.atlassian.net/browse/LF-4841

We need `ChainType` in the /connections /tokens and /chains request. This is so that we can filter out chainTypes we don't want.

This is part 1, part2 will be in lifi-backend. 