### PR TITLE
feat(Chain)!: rename chainType Solana to SVM

### DIFF
--- a/src/chains/Chain.ts
+++ b/src/chains/Chain.ts
@@ -2,7 +2,8 @@ import { ChainKey, CoinKey } from '../base'
 
 export enum ChainType {
   EVM = 'EVM',
-  Solana = 'SOLANA',
+  // Solana virtual machine
+  SVM = 'SVM',
 }
 
 export interface _Chain {

--- a/src/chains/supported.chains.ts
+++ b/src/chains/supported.chains.ts
@@ -1323,7 +1323,7 @@ export const supportedEVMChains: EVMChain[] = [
 export const supportedSolanaChains: SolanaChain[] = [
   {
     key: ChainKey.SOL,
-    chainType: ChainType.Solana,
+    chainType: ChainType.SVM,
     name: 'Solana',
     coin: CoinKey.SOL,
     id: ChainId.SOL,


### PR DESCRIPTION
Since there are new projects leveraging the Solana virtual machine (SVM) as the execution environment it makes sense to broaden the scope of chainTypes. Previously we used Solana as the chainType for the chain Solana. However, since we are concerned with the execution environments we should rather have the chain Solana be a subset of the chainType SVM.

Note: this is a breaking change and will have to wait for the corresponding backend fix before being merged.

BREAKING CHANGE: This changes the chainType for the Solana chain.