### PR TITLE
fix: added wallet analytics request type

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -474,5 +474,4 @@ export interface WalletAnalyticsRequest {
   walletAddress: string
   fromTimestamp: number
   toTimestamp: number
-  integrator?: string
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -469,3 +469,10 @@ export interface WalletAnalytics {
   walletAddress: string
   transactions: StatusResponse[]
 }
+
+export interface WalletAnalyticsRequest {
+  wallet_address: string
+  fromTimestamp: number
+  toTimestamp: number
+  integrator?: string
+}

--- a/src/api.ts
+++ b/src/api.ts
@@ -471,7 +471,7 @@ export interface WalletAnalytics {
 }
 
 export interface WalletAnalyticsRequest {
-  wallet_address: string
+  walletAddress: string
   fromTimestamp: number
   toTimestamp: number
   integrator?: string


### PR DESCRIPTION
There are changes from backend in the request config for the analytics API,
https://github.com/lifinance/lifi-backend/pull/2770

[API Reference](https://apidocs.li.fi/reference/get_analytics-wallets-wallet-address-1)