### PR TITLE
refactor: get tokens request

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -380,7 +380,7 @@ export interface ToolsRequest {
 }
 
 export type TokensRequest = {
-  chains?: ChainId[]
+  chains?: number[] | string[]
   chainTypes?: ChainType[]
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,6 +3,7 @@ import {
   BridgeDefinition,
   Chain,
   ChainId,
+  ChainKey,
   ChainType,
   ExchangeDefinition,
   LifiStep,
@@ -380,7 +381,7 @@ export interface ToolsRequest {
 }
 
 export type TokensRequest = {
-  chains?: number[] | string[]
+  chains?: (ChainId | ChainKey)[]
   chainTypes?: ChainType[]
 }
 


### PR DESCRIPTION
The get tokens endpoint accepts an array of strings as the parameter for chains. It is documented  [here](https://apidocs.li.fi/reference/get_tokens-1). 

The issue with the current type is that Ajv JsonSchemaType will only accept numbers in the schema, stating this error:
```
Property 'type' is missing in type '{ oneOf: { type: string; $ref: string; }[]; }' but required in type 
'{ type: "number" | "integer"; }'.
```
Even with our current schema that contains chain keys and chain ids it will fail showing this error when passing a chain key:
```
{
    "message": "querystring/chains/0 must be integer: /chains/0: must be integer"
}
```
