### PR TITLE
feat!: replace ethers transaction request with custom implementation

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,3 @@
-import { TransactionRequest } from '@ethersproject/providers'
 import {
   BridgeDefinition,
   Chain,
@@ -10,6 +9,30 @@ import {
   Token,
 } from '.'
 import { ToolError } from './apiErrors'
+
+export type BigIntish = string
+
+export type TransactionRequest = {
+  to?: string
+  from?: string
+  nonce?: BigIntish
+
+  gasLimit?: BigIntish
+  gasPrice?: BigIntish
+
+  data?: string
+  value?: BigIntish
+  chainId?: number
+
+  type?: number
+  accessList?: { address: string; storageKeys: string[] }[]
+
+  maxPriorityFeePerGas?: BigIntish
+  maxFeePerGas?: BigIntish
+
+  customData?: Record<string, any>
+  ccipReadEnabled?: boolean
+}
 
 export const Orders = ['RECOMMENDED', 'FASTEST', 'CHEAPEST', 'SAFEST'] as const
 export type Order = (typeof Orders)[number]
@@ -353,9 +376,10 @@ export interface StatusData extends BaseStatusData {
 }
 
 export type StatusResponse = FullStatusData | StatusData
-interface TransferMetadata {
-  integrator: string
-}
+// FIXME: Not used yet
+// interface TransferMetadata {
+//   integrator: string
+// }
 
 export interface FullStatusData extends StatusData {
   transactionId: string
@@ -364,7 +388,7 @@ export interface FullStatusData extends StatusData {
   lifiExplorerLink: string
   fromAddress: string
   toAddress: string
-  metadata: TransferMetadata
+  // metadata: TransferMetadata
   bridgeExplorerLink?: string
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -377,10 +377,9 @@ export interface StatusData extends BaseStatusData {
 }
 
 export type StatusResponse = FullStatusData | StatusData
-// FIXME: Not used yet
-// interface TransferMetadata {
-//   integrator: string
-// }
+interface TransferMetadata {
+  integrator: string
+}
 
 export interface FullStatusData extends StatusData {
   transactionId: string
@@ -389,7 +388,7 @@ export interface FullStatusData extends StatusData {
   lifiExplorerLink: string
   fromAddress: string
   toAddress: string
-  // metadata: TransferMetadata
+  metadata: TransferMetadata
   bridgeExplorerLink?: string
 }
 


### PR DESCRIPTION
This reduces the dependencies on `ethers` as a first step for a viem migration.
This does everything: https://github.com/lifinance/types/pull/183
But we want to do it in steps