### PR TITLE
feat(api)!: use TransactionRequest on Step

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -15,7 +15,7 @@ export type BigIntish = string
 export type TransactionRequest = {
   to?: string
   from?: string
-  nonce?: BigIntish
+  nonce?: number
 
   gasLimit?: BigIntish
   gasPrice?: BigIntish

--- a/src/step.ts
+++ b/src/step.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { providers } from 'ethers'
-import { Substatus } from '.'
+import { Substatus, TransactionRequest } from '.'
 import { Token } from './base'
 import { Bridge } from './bridges'
 import { Exchange, ExchangeAggregator } from './exchanges'
@@ -138,7 +138,7 @@ export interface StepBase {
   action: Action
   estimate?: Estimate
   execution?: Execution
-  transactionRequest?: providers.TransactionRequest
+  transactionRequest?: TransactionRequest
 }
 
 export interface DestinationCallInfo {


### PR DESCRIPTION
Next mini step (from the types perspective, big from Backend perspective) change: Use the new `TransactionRequest` in the `Step`. 
Also I made the `nonce` a number again. I introduced this change in the last PR but that didn't make much sense. `ethers.PopulatedTransaction` and viem both use numbers here