### PR TITLE
chore: add frxETH coinkey

### DIFF
--- a/src/tokens/base.ts
+++ b/src/tokens/base.ts
@@ -54,4 +54,5 @@ export enum CoinKey {
   IF = 'IF',
   RUNE = 'RUNE',
   WMNT = 'WMNT', // Wrapped MNT Token
+  frxETH = 'frxETH',
 }


### PR DESCRIPTION
https://lifi.atlassian.net/browse/LF-2324
the token doesn't have a logo in debank for most of the chains so we need to add it manually in data-types