### PR TITLE
feat: add types for token historic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "16.3.0-beta.0",
+  "version": "16.3.0-beta.1",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "16.3.0-beta.1",
+  "version": "16.3.0-beta.3",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "16.2.2",
+  "version": "16.3.0-beta.0",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/api.ts
+++ b/src/api.ts
@@ -249,6 +249,31 @@ export interface GetTokenRequest {
   token: string
 }
 
+export enum TokenHistoricGranularity {
+  ONE_MIN = '1min',
+  FIVE_MIN = '5min',
+  HOUR = 'hour',
+  DAY = 'day',
+  OVER_DAY = '>day',
+}
+
+export interface GetTokenHistoricRequest {
+  chain: number | string
+  token: string
+  timestamp: number
+  granularity?: TokenHistoricGranularity
+}
+
+export interface TokenPriceHistoricResponse {
+  chainId: number
+  tokenAddress: string
+  isNativeToken: boolean
+  priceUSD: number
+  timestamp: Date
+  timestampMS: number
+  granularity: TokenHistoricGranularity
+}
+
 export interface ToolConfiguration {
   allowBridges?: string[]
   denyBridges?: string[]

--- a/src/api.ts
+++ b/src/api.ts
@@ -268,8 +268,7 @@ export interface TokenPriceHistoricResponse {
   tokenAddress: string
   isNativeToken: boolean
   priceUSD: number
-  timestamp: Date
-  timestampMS: number
+  timestamp: number
   granularity: TokenHistoricGranularity
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -250,8 +250,7 @@ export interface GetTokenRequest {
 }
 
 export enum TokenHistoricGranularity {
-  ONE_MIN = '1min',
-  FIVE_MIN = '5min',
+  THIRTY_MIN = '30min',
   HOUR = 'hour',
   DAY = 'day',
   OVER_DAY = '>day',


### PR DESCRIPTION
Types for token price historic (/token/historic) request and response.

For https://github.com/lifinance/lifi-backend/pull/5759