### PR TITLE
feat(Action): make action.slippage optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "16.10.0",
+  "version": "17.0.0-beta.6",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "17.0.0-beta.6",
+  "version": "17.0.0",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/step.ts
+++ b/src/step.ts
@@ -32,7 +32,7 @@ export interface Action {
   toToken: Token
   toAddress?: string
 
-  slippage: number
+  slippage?: number
 }
 
 // ESTIMATE


### PR DESCRIPTION
Make the `Action.slippage` field optional.
This is a major-version upgrade to v17.x.x