### PR TITLE
chore: change historic token price to string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "16.3.0",
+  "version": "16.3.1-beta.0",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/api.ts
+++ b/src/api.ts
@@ -267,7 +267,7 @@ export interface TokenPriceHistoricResponse {
   chainId: number
   tokenAddress: string
   isNativeToken: boolean
-  priceUSD: number
+  priceUSD: string
   timestamp: number
   granularity: TokenHistoricGranularity
 }


### PR DESCRIPTION
Aligns with rest of API and data model, avoids storing prices as floats.