### PR TITLE
feat: add types for step endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "16.7.0-alpha.1",
+  "version": "16.7.0-beta.1",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/api.ts
+++ b/src/api.ts
@@ -714,3 +714,7 @@ export type TransferSummary = {
 
 export interface TransferSummariesResponse
   extends PaginatedResponse<TransferSummary> {}
+
+export interface GetStepRequest {
+  stepId: string
+}

--- a/src/step.ts
+++ b/src/step.ts
@@ -123,15 +123,15 @@ type StepInformationBase = {
   tool: string
   type: string
   action: Action
-  estimate: Estimate //(w/o `data`)
+  estimate: Estimate
 }
 
 export type StepInformation = StepInformationBase & {
   createdAt: Date
   gasLimit: string
   stepId: string
-  transactionId: string // See acceptance criteria
-  intermediateActions: StepInformationBase[] // the actions from the `includedSteps`
+  transactionId: string
+  intermediateActions: StepInformationBase[]
   integrator?: string
   relatedLifiSteps?: string[]
 }

--- a/src/step.ts
+++ b/src/step.ts
@@ -119,6 +119,23 @@ export type StepToolDetails = {
   logoURI: string
 }
 
+type StepInformationBase = {
+  tool: string
+  type: string
+  action: Action
+  estimate: Estimate //(w/o `data`)
+}
+
+export type StepInformation = StepInformationBase & {
+  createdAt: Date
+  gasLimit: string
+  stepId: string
+  transactionId: string // See acceptance criteria
+  intermediateActions: StepInformationBase[] // the actions from the `includedSteps`
+  integrator?: string
+  relatedLifiSteps?: string[]
+}
+
 export interface StepBase {
   id: string
   type: StepType


### PR DESCRIPTION
https://lifi.atlassian.net/browse/LF-9536

Exposing `StepInformation` type so that new `/step` endpoint can be used by other services with the return type available.

Needed as part of the Ledger quote flow