### PR TITLE
feat: add wfrax coinkey

### DIFF
--- a/src/tokens/base.ts
+++ b/src/tokens/base.ts
@@ -105,4 +105,5 @@ export enum CoinKey {
   WPLU = 'WPLU', // Plume Wrapped Native
   WNIBI = 'WNIBI', // Nibiru Wrapped Native
   WSOPH = 'WSOPH', // Sophon Wrapped Native
+  WFRAX = 'WFRAX', // Fraxtal Wrapped Native
 }


### PR DESCRIPTION
WFRAX is the new wrapped native on Fraxtal after the fork, the old frxETH is still needed though