### PR TITLE
fix: adjust links in README and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Types for the LI.FI stack.
 ## Summary
 
 This package contains all common types for the [LI.FI SDK](https://github.com/lifinance/sdk).
-Learn more about LI.FI on (https://li.fi).
+Learn more about [LI.FI](https://li.fi).
 
 Check out the [Changelog](./CHANGELOG.md) to see what changed in the last releases.
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "homepage": "https://github.com/lifinance/types",
   "bugs": {
-    "url": "https://github.com/lifinance/types"
+    "url": "https://github.com/lifinance/types/issues"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. LI.FI link (README) - Updated link to [LI.FI](https://li.fi) for correct display and clickability.
2. Bugs link (package.json) - Previously, the link was identical to the `homepage` field and led to the root of the `types` repository. Now it points to the repository’s issues URL (https://github.com/lifinance/types/issues) so users can report bugs.