### PR TITLE
feat(intent factory): extend types with if substatus values and deposit

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -513,6 +513,7 @@ export type GetStatusRequest = {
   fromChain?: number | string
   toChain?: number | string
   transactionId?: string
+  depositAddress?: string
 } & ({ txHash: string } | { taskId: string })
 
 export interface BaseTransactionInfo {
@@ -566,6 +567,16 @@ const _SubstatusPending = [
   'REFUND_IN_PROGRESS',
   // We cannot determine the status of the transfer
   'UNKNOWN_ERROR',
+  // Intent is waiting for funds to arrive at the smart contract account
+  'INTENT_AWAITING_FUNDS',
+  // Intent funds detected, preparing execution
+  'INTENT_READY',
+  // Intent is being executed by solver
+  'INTENT_EXECUTING',
+  // Intent execution failed, solver retrying
+  'INTENT_FAILED_RETRYABLE',
+  // Intent simulation failed, solver retrying
+  'INTENT_SIMULATION_FAILURE',
 ] as const
 export type SubstatusPending = (typeof _SubstatusPending)[number]
 


### PR DESCRIPTION
https://linear.app/lifi-linear/issue/CORE-203/extend-lifitypes-with-if-substatus-values-and-deposit-address-status
### Summary
- Add 5 new `INTENT_`-prefixed SubstatusPending values for Intent Factory execution stages.
- Add optional `depositAddress` field to `GetStatusRequest` for SCA-based status polling before a deposit tx is confirmed on-chain

### Context

The Intent Factory integration in `lifi-backend` maps 11 IF FSM states to LiFi statuses. Currently, 5 distinct pending states collapse into the generic `WAIT_DESTINATION_TRANSACTION` substatus, making it impossible for the widget to distinguish between "waiting for funds", "executing", and "retrying after failure". The new typed values let the widget show granular execution progress.

The depositAddress field enables a new status query path where the widget polls by SCA deposit address + fromChain instead of txHash, which is needed before the user's deposit transaction lands on-chain.
