### PR TITLE
docs(fees): describe aggregated Distributions feeCost in FeeSplit.recipients

### DIFF
--- a/src/step.ts
+++ b/src/step.ts
@@ -69,12 +69,11 @@ export interface FeeSplit {
    * new consumers — the aggregate fields above are disjoint slices kept
    * for backward compatibility with 2-recipient consumers.
    *
-   * Note: partner-specified distribution recipients are emitted as
-   * separate `FeeCost` entries (one per receiver, `name: "Fee Forward"`)
-   * at quote/route estimation time. At status-response time the same
-   * recipients may appear merged on the integrator's `FeeCost` for
-   * compactness. Iterate `estimate.feeCosts[]` to discover all
-   * recipients across both shapes. */
+   * Note: partner-specified distribution recipients are aggregated into a
+   * single `FeeCost` entry (`name: "Distributions"`) whose `amount` is the
+   * total distributed and whose `recipients[]` lists each receiver. This
+   * entry sits beside the integrator/LI.FI/intermediary entry, with the same
+   * shape on quote, route, and status responses. */
   recipients?: FeeRecipient[]
 }
 


### PR DESCRIPTION
## What

Update the `FeeSplit.recipients` JSDoc to describe the aggregated `Distributions` fee shape.

Partner distribution recipients are now reported as one `FeeCost` entry named `Distributions` — its `amount` is the total distributed and `recipients[]` lists each receiver — beside the integrator/LI.FI/intermediary entry. Same shape on quote, route, and status responses.

## Why

The doc still described the old behavior: per-receiver `Fee Forward` entries at quote time and a merged-on-integrator shape at status time. The backend now emits the single aggregated entry consistently, so consumers reading this contract were misinformed.

Doc-only change — no type signature changes.

## Related

Backend change: lifinance/lifi-backend#8479 (CORE-513).
