### PR TITLE
feat: add permissioned disableFees request param

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -208,6 +208,16 @@ export interface RouteOptions extends RouteOptionsBase {
    */
   distributionFees?: DistributionFee[]
 
+  /**
+   * Disable the backend integrator fee for this request.
+   *
+   * Permissioned: honoured only for allowlisted integrations (authenticated via
+   * their API key). Non-allowlisted callers that set it are ignored and charged
+   * normally. Attribution and integrator-specific config still resolve from
+   * `integrator` — only the fee is suppressed.
+   */
+  disableFees?: boolean
+
   /** Integrators can set a wallet address as a referrer to track them */
   referrer?: string
 
@@ -429,6 +439,8 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
   distributionFees?: DistributionFee[]
   referrer?: string
   fee?: number | string
+  /** @see {@link RouteOptions.disableFees} */
+  disableFees?: boolean
 
   /** Whether destination calls are enabled by default
    * @default true */
@@ -498,6 +510,8 @@ type PartialContractCallsQuoteRequest = ToolConfiguration & {
   integrator?: string
   referrer?: string
   fee?: number | string
+  /** @see {@link RouteOptions.disableFees} */
+  disableFees?: boolean
   allowDestinationCall?: boolean // (default : true) // destination calls are enabled by default
 }
 


### PR DESCRIPTION
## What

Adds an optional `disableFees?: boolean` to three request types in `src/api.ts`:

- `RouteOptions` (full JSDoc)
- `QuoteRequest` (`@see`-linked)
- `PartialContractCallsQuoteRequest` — feeds the `ContractCallsQuoteRequest` union (`@see`-linked)

`QuoteToAmountRequest` inherits it automatically (`Omit<QuoteRequest, …>`).

## Why

The LI.FI backend gained a permissioned `disableFees` param (CORE-364): when set by an **allowlisted, API-key-authenticated** integration it suppresses the backend integrator fee, while attribution and integrator-specific config still resolve from `integrator`. Composer is the first consumer — it forwards an `integrator` for attribution but owns fee injection for its own `/compose` flows.

Today the backend declares this field via a **backend-local module augmentation** of `@lifi/types`. That means any team consuming the published types package (e.g. Composer) can't see or use the field. Moving it into the package proper fixes that.

Requested in review of the backend PR: lifinance/lifi-backend#8549 (review thread `r3542359767`).

## Notes

- Authorization stays server-side; the type just documents the param so consumers can set it.
- After this merges + a **beta release**, the backend PR switches `@lifi/types` to the new version and deletes its local augmentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)