### PR TITLE
feat: partners need intermediary fee type for fee resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "17.86.0",
+  "version": "17.87.0-beta.0",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/api.ts
+++ b/src/api.ts
@@ -891,6 +891,7 @@ export enum IntegratorFeeType {
   FIXED = 'FIXED',
   SHARED = 'SHARED',
   DYNAMIC = 'DYNAMIC',
+  INTERMEDIARY = 'INTERMEDIARY',
 }
 
 export type TransferSummary = {


### PR DESCRIPTION
## Which Linear task is linked to this PR?
https://linear.app/lifi-linear/issue/PAR-845/add-intermediary-fee-support-to-fee-resolve-endpoint

## Why was it implemented this way?
Add new `INTERMEDIARY` feeType in `IntegratorFeeType` enum

## Visual showcase (Screenshots or Videos)
_If applicable, attach screenshots, GIFs, or videos to showcase the functionality, UI changes, or bug fixes._

## Checklist before requesting a review
- [ ] I have performed a self-review and testing of my code.
- [ ] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Types API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.
