### PR TITLE
feat: add amountFlexible route option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "17.87.0-beta.0",
+  "version": "17.87.0-beta.1",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/api.ts
+++ b/src/api.ts
@@ -227,6 +227,16 @@ export interface RouteOptions extends RouteOptionsBase {
    * When provided, this preset will override other route options with optimized settings */
   preset?: string
 
+  /** Opt into amount-flexible routing where the underlying tool supports it.
+   * Instead of a fixed minimum output, an amount-flexible route carries a signed
+   * rate floor, a minimum deposit and a rate expiry alongside a deposit address:
+   * any amount at or above the minimum, funded within the window, executes at
+   * the live price no worse than the floor. Currently honored only by
+   * cross-chain Smart Deposit Address routes; ignored by tools that do not
+   * support it.
+   * @default false */
+  amountFlexible?: boolean
+
   /** Whether the user wants to insure their tx
    * @deprecated This property is deprecated and will be removed in future versions. */
   insurance?: boolean


### PR DESCRIPTION
## What

Adds `amountFlexible?: boolean` to `RouteOptions` — the per-request opt-in for amount-flexible (solve-time-quoted) Smart Deposit routes. An amount-flexible route carries a signed rate floor, a minimum deposit and a rate expiry alongside the deposit address; any amount at or above the minimum, funded within the window, executes at the live price no worse than the floor.

Consumed by lifinance/lifi-backend#8662, which currently declares the field locally in its AJV route-options schema; once this ships, the backend types against the package instead.

Supersedes #541 — same change, but that branch is based on 17.85.0-era main. #541 can be closed.

## Release plan

Beta released from this branch per the beta process; official release once lifi-backend#8662 is merged and verified against it. Not to be merged before then.