### PR TITLE
feat: add destinationAction params to QuoteRequest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "17.87.0-beta.1",
+  "version": "17.87.0-beta.2",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "17.87.0-beta.0",
+  "version": "17.87.0-beta.1",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/api.ts
+++ b/src/api.ts
@@ -227,6 +227,16 @@ export interface RouteOptions extends RouteOptionsBase {
    * When provided, this preset will override other route options with optimized settings */
   preset?: string
 
+  /** Opt into amount-flexible routing where the underlying tool supports it.
+   * Instead of a fixed minimum output, an amount-flexible route carries a signed
+   * rate floor, a minimum deposit and a rate expiry alongside a deposit address:
+   * any amount at or above the minimum, funded within the window, executes at
+   * the live price no worse than the floor. Currently honored only by
+   * cross-chain Smart Deposit Address routes; ignored by tools that do not
+   * support it.
+   * @default false */
+  amountFlexible?: boolean
+
   /** Whether the user wants to insure their tx
    * @deprecated This property is deprecated and will be removed in future versions. */
   insurance?: boolean

--- a/src/api.ts
+++ b/src/api.ts
@@ -434,6 +434,14 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
    * @default true */
   allowDestinationCall?: boolean
 
+  /** Requests a destination-side action executed after the bridge leg (Smart Deposits routes only).
+   *  Must be sent together with `destinationActionVault`; cross-chain EVM routes only. */
+  destinationActionKind?: 'erc4626_deposit'
+
+  /** The ERC-4626 vault the bridged funds are deposited into. Must be on the curated allowlist
+   *  and its underlying asset must equal `toToken`. Must be sent together with `destinationActionKind`. */
+  destinationActionVault?: string
+
   /** The amount of token to convert to gas */
   fromAmountForGas?: string
 


### PR DESCRIPTION
## What this does
Adds the two Smart Deposits destination-action params to `QuoteRequest`, matching what lifi-backend#8687 accepts on `GET /v1/quote`:

- `destinationActionKind?: 'erc4626_deposit'`
- `destinationActionVault?: string`

Both-or-neither pairing, allowlist enforcement and route eligibility are all backend concerns — this is the type surface only.

## Heads-up for reviewers
- **Stacked on #552** (`feat/route-options-amount-flexible-2`) so the beta releases stay supersets of each other — merge #552 first; this PR then shows only the one commit.
- Consumed by [lifi-backend#8687](https://github.com/lifinance/lifi-backend/pull/8687); the backend keeps working against its local widening until the official release replaces the pin.
