### PR TITLE
feat: add amountFlexible route option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "17.87.0",
+  "version": "17.88.0-beta.0",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "17.88.0-beta.0",
+  "version": "17.87.0",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/api.ts
+++ b/src/api.ts
@@ -227,6 +227,16 @@ export interface RouteOptions extends RouteOptionsBase {
    * When provided, this preset will override other route options with optimized settings */
   preset?: string
 
+  /** Opt into amount-flexible routing where the underlying tool supports it.
+   * Instead of a fixed minimum output, an amount-flexible route carries a signed
+   * rate floor, a minimum deposit and a rate expiry alongside a deposit address:
+   * any amount at or above the minimum, funded within the window, executes at
+   * the live price no worse than the floor. Currently honored only by
+   * cross-chain Smart Deposit Address routes; ignored by tools that do not
+   * support it.
+   * @default false */
+  amountFlexible?: boolean
+
   /** Whether the user wants to insure their tx
    * @deprecated This property is deprecated and will be removed in future versions. */
   insurance?: boolean


### PR DESCRIPTION
Adds `RouteOptions.amountFlexible?: boolean` (default `false`) — the route-options opt-in for amount-flexible Smart Deposits, consumed by lifi-backend #8662.

Supersedes #552: the 17.87.0 version line that PR's beta was pre-releasing toward was taken by an unrelated official release on 2026-07-29, leaving its version bump conflicting. Same source change (cherry-picked from it), redone off current `main`.

Released from this branch: **`17.88.0-beta.0`** (tag `v17.88.0-beta.0`).

⚠️ Do not merge until the official release step — this is rung 1 of a three-PR stack (amountFlexible → quote destinationAction params → destinationAction object surface), merged in order once the consuming lifi-backend PRs are finalized.