### PR TITLE
feat: add destinationAction params to QuoteRequest

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -3,6 +3,7 @@ import type { Chain, ChainId, ChainKey, ChainType } from './chains/index.js'
 import type { ExchangeDefinition } from './exchanges.js'
 import type {
   Action,
+  DestinationActionKind,
   FeeCost,
   LiFiStep,
   SignedLiFiStep,
@@ -448,7 +449,7 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
 
   /** Requests a destination-side action executed after the bridge leg (Smart Deposits routes only).
    *  Must be sent together with `destinationActionVault`; cross-chain EVM routes only. */
-  destinationActionKind?: 'erc4626_deposit'
+  destinationActionKind?: DestinationActionKind
 
   /** The ERC-4626 vault the bridged funds are deposited into. Must be on the curated allowlist
    *  and its underlying asset must equal `toToken`. Must be sent together with `destinationActionKind`. */
@@ -487,7 +488,13 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
 
 export interface QuoteToAmountRequest extends Omit<
   QuoteRequest,
-  'fromAmount' | 'fromAmountForGas' | 'insurance'
+  // Destination actions are excluded: a target output amount cannot be
+  // inverted across the action leg, and the endpoint rejects the params.
+  | 'fromAmount'
+  | 'fromAmountForGas'
+  | 'insurance'
+  | 'destinationActionKind'
+  | 'destinationActionVault'
 > {
   toAmount: string
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -446,6 +446,14 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
    * @default true */
   allowDestinationCall?: boolean
 
+  /** Requests a destination-side action executed after the bridge leg (Smart Deposits routes only).
+   *  Must be sent together with `destinationActionVault`; cross-chain EVM routes only. */
+  destinationActionKind?: 'erc4626_deposit'
+
+  /** The ERC-4626 vault the bridged funds are deposited into. Must be on the curated allowlist
+   *  and its underlying asset must equal `toToken`. Must be sent together with `destinationActionKind`. */
+  destinationActionVault?: string
+
   /** The amount of token to convert to gas */
   fromAmountForGas?: string
 

--- a/src/step.ts
+++ b/src/step.ts
@@ -225,6 +225,13 @@ export interface CustomStep extends StepBase {
 
 export type Step = SwapStep | CrossStep | CustomStep | ProtocolStep
 
+/** Destination-side actions the Smart Deposits lane can execute once the
+ * bridged funds land. A closed set: the kind is the forward-compatibility
+ * axis, so a new action ships as a new literal rather than a free-form string. */
+export const DESTINATION_ACTION_KINDS = ['erc4626_deposit'] as const
+
+export type DestinationActionKind = (typeof DESTINATION_ACTION_KINDS)[number]
+
 export interface LiFiStep extends Omit<Step, 'type'> {
   type: 'lifi'
   includedSteps: Step[]


### PR DESCRIPTION
Adds the two flat destination-action params to `QuoteRequest` for the Smart Deposits destination-action lane (lifi-backend #8687):

- `destinationActionKind?: DestinationActionKind` — typed via a new exported closed set (`DESTINATION_ACTION_KINDS` / `DestinationActionKind` in `step.ts`), so the literal exists once in the package.
- `destinationActionVault?: string`
- `QuoteToAmountRequest` explicitly **omits** both: `/v1/quote/toAmount` cannot invert a target amount across the action leg and rejects the params server-side — the published type must not advertise them.

Supersedes #553 (same version-line burn as #552 → #555; its cherry-picked source commit is preserved here, refinements on top).

Released from this branch: **`17.88.0-beta.1`** (tag `v17.88.0-beta.1`).

⚠️ Rung 2 of the stack on #555 — do not merge until the official release step; merge order #555 → this → rung 3.