### PR TITLE
feat: add DestinationAction to RouteOptions and LiFiStep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "17.88.0-beta.1",
+  "version": "17.88.0-beta.2",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "17.88.0-beta.0",
+  "version": "17.88.0-beta.1",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "17.87.0",
+  "version": "17.88.0-beta.0",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,6 +3,7 @@ import type { Chain, ChainId, ChainKey, ChainType } from './chains/index.js'
 import type { ExchangeDefinition } from './exchanges.js'
 import type {
   Action,
+  DestinationActionKind,
   FeeCost,
   LiFiStep,
   SignedLiFiStep,
@@ -436,7 +437,7 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
 
   /** Requests a destination-side action executed after the bridge leg (Smart Deposits routes only).
    *  Must be sent together with `destinationActionVault`; cross-chain EVM routes only. */
-  destinationActionKind?: 'erc4626_deposit'
+  destinationActionKind?: DestinationActionKind
 
   /** The ERC-4626 vault the bridged funds are deposited into. Must be on the curated allowlist
    *  and its underlying asset must equal `toToken`. Must be sent together with `destinationActionKind`. */
@@ -475,7 +476,13 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
 
 export interface QuoteToAmountRequest extends Omit<
   QuoteRequest,
-  'fromAmount' | 'fromAmountForGas' | 'insurance'
+  // Destination actions are excluded: a target output amount cannot be
+  // inverted across the action leg, and the endpoint rejects the params.
+  | 'fromAmount'
+  | 'fromAmountForGas'
+  | 'insurance'
+  | 'destinationActionKind'
+  | 'destinationActionVault'
 > {
   toAmount: string
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,6 +3,7 @@ import type { Chain, ChainId, ChainKey, ChainType } from './chains/index.js'
 import type { ExchangeDefinition } from './exchanges.js'
 import type {
   Action,
+  DestinationAction,
   DestinationActionKind,
   FeeCost,
   LiFiStep,
@@ -237,6 +238,13 @@ export interface RouteOptions extends RouteOptionsBase {
    * support it.
    * @default false */
   amountFlexible?: boolean
+
+  /** Requests a destination-side action executed after the bridge leg
+   * (cross-chain EVM Smart Deposits routes only). The returned route's Smart
+   * Deposits step carries the action — post that step unchanged to
+   * `/v1/advanced/stepTransaction`. Routes that cannot execute the action are
+   * rejected or excluded rather than silently served without it. */
+  destinationAction?: DestinationAction
 
   /** Whether the user wants to insure their tx
    * @deprecated This property is deprecated and will be removed in future versions. */

--- a/src/api.ts
+++ b/src/api.ts
@@ -434,6 +434,14 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
    * @default true */
   allowDestinationCall?: boolean
 
+  /** Requests a destination-side action executed after the bridge leg (Smart Deposits routes only).
+   *  Must be sent together with `destinationActionVault`; cross-chain EVM routes only. */
+  destinationActionKind?: 'erc4626_deposit'
+
+  /** The ERC-4626 vault the bridged funds are deposited into. Must be on the curated allowlist
+   *  and its underlying asset must equal `toToken`. Must be sent together with `destinationActionKind`. */
+  destinationActionVault?: string
+
   /** The amount of token to convert to gas */
   fromAmountForGas?: string
 

--- a/src/step.ts
+++ b/src/step.ts
@@ -225,6 +225,13 @@ export interface CustomStep extends StepBase {
 
 export type Step = SwapStep | CrossStep | CustomStep | ProtocolStep
 
+/** Destination-side actions the Smart Deposits lane can execute once the
+ * bridged funds land. A closed set: the kind is the forward-compatibility
+ * axis, so a new action ships as a new literal rather than a free-form string. */
+export const DESTINATION_ACTION_KINDS = ['erc4626_deposit'] as const
+
+export type DestinationActionKind = (typeof DESTINATION_ACTION_KINDS)[number]
+
 export interface LiFiStep extends Omit<Step, 'type'> {
   type: 'lifi'
   includedSteps: Step[]

--- a/src/step.ts
+++ b/src/step.ts
@@ -232,9 +232,23 @@ export const DESTINATION_ACTION_KINDS = ['erc4626_deposit'] as const
 
 export type DestinationActionKind = (typeof DESTINATION_ACTION_KINDS)[number]
 
+/** One destination-side action, executed by the Smart Deposits lane on the
+ * destination chain after the bridge leg. The vault address is forwarded
+ * verbatim — the Intent Factory's curated allowlist is the enforcement point. */
+export interface DestinationAction {
+  kind: DestinationActionKind
+  vault: string
+}
+
 export interface LiFiStep extends Omit<Step, 'type'> {
   type: 'lifi'
   includedSteps: Step[]
+
+  /** Present on Smart Deposits steps whose route was requested with a
+   * destination action. Round-trip the step unchanged to
+   * `/v1/advanced/stepTransaction` — a step posted without it prepares a
+   * plain bundle that delivers the raw token instead of the action's output. */
+  destinationAction?: DestinationAction
 }
 
 export interface SignedLiFiStep extends LiFiStep {


### PR DESCRIPTION
Completes the destination-action public surface (lifi-backend #8705):

- `DestinationAction { kind: DestinationActionKind; vault: string }` exported from `step.ts`.
- `RouteOptions.destinationAction?: DestinationAction` — the `POST /v1/advanced/routes` entry point.
- `LiFiStep.destinationAction?: DestinationAction` — the returned step carries the action on the wire and must be round-tripped unchanged to `/v1/advanced/stepTransaction`; typed clients would otherwise drop it.

With this rung, one official release collapses every local widening in lifi-backend's `destinationAction.types.ts` (#8687 + #8705).

Released from this branch: **`17.88.0-beta.2`** (tag `v17.88.0-beta.2`).

⚠️ Rung 3 of the stack (#555 → #556 → this) — do not merge until the official release step.