### PR TITLE
feat: add gasless request flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [18.3.0](https://github.com/lifinance/types/compare/v18.2.0...v18.3.0) (2026-08-27)
+
+
+### Features
+
+* add gasless request flags to `QuoteRequest` and `RouteOptions` ([ff71a15](https://github.com/lifinance/types/commit/ff71a15beaa9599b7083550ebfb3996a8b6c7494))
+
 ## [18.2.0](https://github.com/lifinance/types/compare/v18.1.0...v18.2.0) (2026-08-05)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "18.2.0",
+  "version": "18.3.0-beta.0",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "18.3.0-beta.0",
+  "version": "18.3.0",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/api.ts
+++ b/src/api.ts
@@ -167,7 +167,7 @@ export interface RouteOptionsBase {
 
   /** Opt the request into gasless execution. The returned steps carry signable
    * typed data instead of a `transactionRequest`, and a relay fee is deducted
-   * from the input amount as a `LIFI_GASLESS_RELAY_FEE_NAME` fee cost.
+   * from the input amount as a `feeCosts` entry named `LIFI Gasless Relay Fee`.
    * @default false */
   gasless?: boolean
 }
@@ -501,7 +501,7 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
 
   /** Opt the request into gasless execution. The response returns signable
    * typed data instead of a `transactionRequest`, and a relay fee is deducted
-   * from the input amount as a `LIFI_GASLESS_RELAY_FEE_NAME` fee cost.
+   * from the input amount as a `feeCosts` entry named `LIFI Gasless Relay Fee`.
    * @default false */
   gasless?: boolean
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -164,6 +164,12 @@ export interface RouteOptionsBase {
   /** Whether to include routes that require a transaction or a message, or both
    * @default 'transaction' */
   executionType?: ExecutionType
+
+  /** Opt the request into gasless execution. The returned steps carry signable
+   * typed data instead of a `transactionRequest`, and a relay fee is deducted
+   * from the input amount as a `LIFI_GASLESS_RELAY_FEE_NAME` fee cost.
+   * @default false */
+  gasless?: boolean
 }
 
 /**
@@ -492,6 +498,12 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
   /** The execution type of the quote
    * @default 'transaction' */
   executionType?: ExecutionType
+
+  /** Opt the request into gasless execution. The response returns signable
+   * typed data instead of a `transactionRequest`, and a relay fee is deducted
+   * from the input amount as a `LIFI_GASLESS_RELAY_FEE_NAME` fee cost.
+   * @default false */
+  gasless?: boolean
 
   /** SVM specific option, without it implicit source swaps routes are discarded */
   jitoBundle?: boolean

--- a/src/step.ts
+++ b/src/step.ts
@@ -77,6 +77,17 @@ export interface FeeSplit {
   recipients?: FeeRecipient[]
 }
 
+/**
+ * `FeeCost.name` of the relay fee charged for gasless execution, added to
+ * `Estimate.feeCosts` when a quote is requested with `gasless: true`. This is
+ * the stable identifier for that entry — match on it rather than on the
+ * human-readable `description`, which may change.
+ *
+ * The entry always has `included: true`: the fee is taken out of the input
+ * amount, so the user does not send anything on top of `fromAmount`.
+ */
+export const LIFI_GASLESS_RELAY_FEE_NAME = 'LIFI Gasless Relay Fee'
+
 export interface FeeCost {
   name: string
   description: string

--- a/src/step.ts
+++ b/src/step.ts
@@ -77,17 +77,6 @@ export interface FeeSplit {
   recipients?: FeeRecipient[]
 }
 
-/**
- * `FeeCost.name` of the relay fee charged for gasless execution, added to
- * `Estimate.feeCosts` when a quote is requested with `gasless: true`. This is
- * the stable identifier for that entry — match on it rather than on the
- * human-readable `description`, which may change.
- *
- * The entry always has `included: true`: the fee is taken out of the input
- * amount, so the user does not send anything on top of `fromAmount`.
- */
-export const LIFI_GASLESS_RELAY_FEE_NAME = 'LIFI Gasless Relay Fee'
-
 export interface FeeCost {
   name: string
   description: string


### PR DESCRIPTION
## What

Adds the `gasless` request flag for the gasless EVM execution surface (M2 slice of the gasless types train):

- `gasless?: boolean` on `QuoteRequest` — opts the quote into gasless execution: the response returns signable typed data instead of a `transactionRequest`, and the relay fee is deducted from the input amount. Default `false`.
- `gasless?: boolean` on `RouteOptionsBase` — the same flag for `/advanced/routes`, placed with the other execution-shape options (`executionType`, `allowDestinationCall`).

The relay-fee `FeeCost` name constant originally included here was removed: the fee-name constants integrators match on (`LIFI_SHARED_FEE_NAME` and friends) live in the backend and are published through the docs — `FeeCost.name` stays a plain string in this package.

## Why

Linear: https://linear.app/lifi-linear/issue/CORE-790

Phase 1 of gasless EVM execution (EIP-7702 batched approve+swap). The backend implementation consumes this via a beta release; the intent factory follows.

## Release

No version bump / CHANGELOG edit — standard-version owns both. After merge: `pnpm release:beta` + tag push to cut the beta for lifi-backend and intent factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)