### PR TITLE
feat: add DestinationAction to RouteOptions and LiFiStep

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -3,6 +3,7 @@ import type { Chain, ChainId, ChainKey, ChainType } from './chains/index.js'
 import type { ExchangeDefinition } from './exchanges.js'
 import type {
   Action,
+  DestinationAction,
   DestinationActionKind,
   FeeCost,
   LiFiStep,
@@ -251,6 +252,13 @@ export interface RouteOptions extends RouteOptionsBase {
    * support it.
    * @default false */
   amountFlexible?: boolean
+
+  /** Requests a destination-side action executed after the bridge leg
+   * (cross-chain EVM Smart Deposits routes only). The returned route's Smart
+   * Deposits step carries the action — post that step unchanged to
+   * `/v1/advanced/stepTransaction`. Routes that cannot execute the action are
+   * rejected or excluded rather than silently served without it. */
+  destinationAction?: DestinationAction
 
   /** Whether the user wants to insure their tx
    * @deprecated This property is deprecated and will be removed in future versions. */

--- a/src/step.ts
+++ b/src/step.ts
@@ -232,9 +232,23 @@ export const DESTINATION_ACTION_KINDS = ['erc4626_deposit'] as const
 
 export type DestinationActionKind = (typeof DESTINATION_ACTION_KINDS)[number]
 
+/** One destination-side action, executed by the Smart Deposits lane on the
+ * destination chain after the bridge leg. The vault address is forwarded
+ * verbatim — the Intent Factory's curated allowlist is the enforcement point. */
+export interface DestinationAction {
+  kind: DestinationActionKind
+  vault: string
+}
+
 export interface LiFiStep extends Omit<Step, 'type'> {
   type: 'lifi'
   includedSteps: Step[]
+
+  /** Present on Smart Deposits steps whose route was requested with a
+   * destination action. Round-trip the step unchanged to
+   * `/v1/advanced/stepTransaction` — a step posted without it prepares a
+   * plain bundle that delivers the raw token instead of the action's output. */
+  destinationAction?: DestinationAction
 }
 
 export interface SignedLiFiStep extends LiFiStep {


### PR DESCRIPTION
Second half of the destination-action surface — the request/response route types. The `QuoteRequest` half (flat `destinationActionKind` / `destinationActionVault` params + `DESTINATION_ACTION_KINDS`) shipped in #556 / 17.90.0.

- `RouteOptions.destinationAction?: DestinationAction` — requests a destination-side action on `POST /v1/advanced/routes` (cross-chain EVM Smart Deposits routes only)
- `DestinationAction { kind, vault }` interface in `step.ts`
- `LiFiStep.destinationAction?` — present on Smart Deposits steps whose route was requested with an action; the step round-trips unchanged to `/v1/advanced/stepTransaction`

Replaces #557, which carried stack residue from the pre-17.90.0 beta ladder — this is the same single payload commit rebased clean onto `main` (17.90.0).

Consumer: lifi-backend #8705 (routes-level fail-closed guards), which retires its repo-local module widening once this lands.