### PR TITLE
fix(api): resolve multiple documentation and type inconsistencies

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -348,7 +348,7 @@ export interface Route {
 
   gasCostUSD?: string // Aggregation of underlying gas costs in usd
 
-  containsSwitchChain?: boolean // Features required for route execution
+  containsSwitchChain?: boolean // Whether the route contains a chain switch during execution
 
   steps: LiFiStep[]
 
@@ -588,7 +588,9 @@ export const isContractCallsRequestWithToAmount = (
   r: ContractCallsQuoteRequestFromAmount | ContractCallsQuoteRequestToAmount
 ): r is ContractCallsQuoteRequestToAmount => 'toAmount' in r
 
-/* @deprecated */
+/**
+* @deprecated ContractCallQuoteRequest is deprecated and will be removed in future versions.
+*/
 export interface ContractCallQuoteRequest extends ToolConfiguration {
   fromChain: number | string
   fromToken: string
@@ -670,7 +672,7 @@ export interface PendingReceivingInfo {
 const _StatusMessage = [
   // The transaction was not found -- likely not mined yet
   'NOT_FOUND',
-  // A third party service is not available
+  // The txHash is not tied to the requested tool (bridge / chains)
   'INVALID',
   // The transfer is pending
   'PENDING',
@@ -1091,7 +1093,7 @@ export type RelayResponseData = {
 export type RelayResponse = RelayerResponse<RelayResponseData>
 
 export type RelayStatusRequest = {
-  taskId: Hash
+  taskId: string
   bridge?: string
   fromChain?: number
   toChain?: number


### PR DESCRIPTION
## Which Linear task is linked to this PR?
This PR was written during a project review.

## Why was it implemented this way?
Four independent issues fixed in one PR since all changes are in the same file (`src/api.ts`):
- [`containsSwitchChain (Line ~351)`](https://github.com/lifinance/types/blob/main/src/api.ts#L351)
**Why:** The comment `// Features required for route execution` was semantically incorrect - the field is a boolean flag indicating chain switches, not a feature list
**Chosen:** Updated to accurately describe the field's purpose

- [`@deprecated annotation (Line ~591)`](https://github.com/lifinance/types/blob/main/src/api.ts#L591)
**Why:** Block comments `/* */` are not recognized by TypeScript/IDE tooling; only JSDoc `/** */` triggers deprecation warnings
**Chosen:** Converted to proper JSDoc format, consistent with other deprecated types in the file

- [`INVALID status comment (Line ~673)`](https://github.com/lifinance/types/blob/main/src/api.ts#L673-L674)
**Why:** The comment `// A third party service is not available` contradicts official LI.FI documentation where INVALID means "Hash is not tied to the requested tool"
**Chosen:** Updated to match official docs

- [`RelayStatusRequest.taskId type (Lines ~1094)`](https://github.com/lifinance/types/blob/main/src/api.ts#L1094)
**Why:** `RelayResponseData.taskId` returns a string (UUID), but `RelayStatusRequest.taskId` expected `Hash` (`0x${string}`), causing type errors when passing taskId from response to status request
**Chosen:** Changed `RelayStatusRequest.taskId` to `string` - widens the type safely (`Hash` is subset of `string`) and enables type-safe usage without `as Hash` assertions

All changes are backward compatible and maintain the same runtime behavior.
