### PR TITLE
feat: add refundAddress to QuoteRequest and Action

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "18.4.0",
+  "version": "18.5.0-beta.1",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "18.5.0-beta.1",
+  "version": "18.4.0",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/api.ts
+++ b/src/api.ts
@@ -460,7 +460,6 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
   toChain: number | string
   toToken: string
   toAddress?: string
-  /** Refund recipient on the origin chain for a bridge that cannot deliver. Defaults to fromAddress. */
   refundAddress?: string
 
   order?: Order

--- a/src/api.ts
+++ b/src/api.ts
@@ -460,6 +460,8 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
   toChain: number | string
   toToken: string
   toAddress?: string
+  /** Refund recipient on the origin chain for a bridge that cannot deliver. Defaults to fromAddress. */
+  refundAddress?: string
 
   order?: Order
   slippage?: number | string

--- a/src/step.ts
+++ b/src/step.ts
@@ -109,7 +109,6 @@ export interface Action {
   toChainId: number
   toToken: Token
   toAddress?: string
-  /** Refund recipient on the origin chain when the carrier honours one. */
   refundAddress?: string
 
   slippage?: number

--- a/src/step.ts
+++ b/src/step.ts
@@ -109,6 +109,8 @@ export interface Action {
   toChainId: number
   toToken: Token
   toAddress?: string
+  /** Refund recipient on the origin chain when the carrier honours one. */
+  refundAddress?: string
 
   slippage?: number
 }


### PR DESCRIPTION
Adds an optional `refundAddress` to `QuoteRequest` (the origin-chain refund recipient a bridge should use when it cannot deliver; defaults to `fromAddress`) and to `Action` (the value the backend carried, echoed on the step). Consumed by lifi-backend #8929 for Smart Deposits, where the sender is a deposit account the user cannot recover funds from.

Beta published from this branch as `@lifi/types@18.5.0-beta.1`. Do not merge until the backend PR is approved; then cut the official release.