### PR TITLE
feat: expose source-chain principal refund recipients

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,8 @@ jobs:
           generate_release_notes: true
           name: ${{ github.ref_name }}
           draft: false
-          prerelease: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ contains(github.ref_name, '-') && 'false' || 'true' }}
 
   publish:
     permissions:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/types",
-  "version": "18.5.0",
+  "version": "18.6.0-beta.0",
   "description": "Types for the LI.FI stack",
   "keywords": [
     "sdk",

--- a/src/api.ts
+++ b/src/api.ts
@@ -233,6 +233,15 @@ export interface RouteOptions extends RouteOptionsBase {
   /** Integrators can set a wallet address as a referrer to track them */
   referrer?: string
 
+  /**
+   * Recipient of source-chain bridge principal refunds, independent of the
+   * funding sender and successful recipient. Must be valid on the source chain.
+   * When supplied, bridges and quote variants that cannot honor it are excluded
+   * or rejected rather than falling back to the sender. Does not redirect
+   * destination swap/call recovery. Omission preserves the bridge's default.
+   */
+  refundAddress?: string
+
   /** SVM specific option, without it implicit source swaps routes are discarded */
   jitoBundle?: boolean
 
@@ -460,6 +469,7 @@ export interface QuoteRequest extends ToolConfiguration, TimingStrings {
   toChain: number | string
   toToken: string
   toAddress?: string
+  /** @see {@link RouteOptions.refundAddress} */
   refundAddress?: string
 
   order?: Order
@@ -551,6 +561,8 @@ type PartialContractCallsQuoteRequest = ToolConfiguration & {
   fromChain: number | string
   fromToken: string
   fromAddress: string
+  /** @see {@link RouteOptions.refundAddress} */
+  refundAddress?: string
 
   toChain: number | string
   toToken: string
@@ -594,6 +606,8 @@ export interface ContractCallQuoteRequest extends ToolConfiguration {
   fromChain: number | string
   fromToken: string
   fromAddress: string
+  /** @see {@link RouteOptions.refundAddress} */
+  refundAddress?: string
   toChain: number | string
   toToken: string
   toAmount: string

--- a/src/step.ts
+++ b/src/step.ts
@@ -109,6 +109,7 @@ export interface Action {
   toChainId: number
   toToken: Token
   toAddress?: string
+  /** Recipient of source-chain bridge principal refunds, not destination swap/call recovery. */
   refundAddress?: string
 
   slippage?: number


### PR DESCRIPTION
## Which Linear task is linked to this PR?

[CORE-1248 — Allow passing different refund address than sender address](https://linear.app/lifi-linear/issue/CORE-1248/allow-passing-different-refund-address-than-sender-address)

## Why was it implemented this way?

- Expose optional `refundAddress` on `RouteOptions`, both contract-calls amount variants through their shared request type, and the deprecated single-call request.
- Document the existing quote/action fields consistently: source-chain bridge principal refunds only, separate from funding and successful recipients; destination swap/call recovery is unchanged. Unsupported bridges/quote variants must reject or be excluded, not silently fall back.
- Preserve tag-triggered alpha/beta prerelease handling so prereleases do not replace the latest stable release. The reconciliation retains main’s package version `18.9.0`; it does not publish or tag a new version.
- Backend PR [lifinance/lifi-backend#8948](https://github.com/lifinance/lifi-backend/pull/8948) now consumes published `18.9.0` and retains its existing request-type widening until these additional declarations are released.

## Verification

- `pnpm exec eslint src`: passed with four existing warnings.
- `pnpm typecheck`: passed.
- `pnpm build`: CJS, ESM and declarations passed.
- Throwaway consumer compiled against generated declarations: all seven request/action surfaces accept a string recipient or omission and reject a numeric recipient. Smoke file removed.
- No on-chain transactions submitted.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] Public-docs documentation updated. Backend OpenAPI and public type comments are updated; public-docs has not been changed.

## Release note

Beta only; no stable npm release or production backend deployment is requested.

Original beta publication (historical): [Release & Publish run](https://github.com/lifinance/types/actions/runs/34473048338) succeeded; npm `beta` was `18.6.0-beta.0` and `latest` remained `18.5.0` at that time, and the GitHub release is marked as a prerelease. Backend consumption passed root typechecking, pre-push checks and 27 targeted API/refund tests.


### Main reconciliation — 2026-09-16

Merged main `b108a3e` in `8591552`, retaining version `18.9.0` and all refund declarations. Build (CJS/ESM/declarations), typecheck and ESLint passed (four warnings). A temporary consumer verified string/omission support across six request/action type surfaces and rejection of numeric recipients; removed afterward. No new publication or deployment.
