### PR TITLE
feat: add per-side liquidity source parameters

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -470,9 +470,7 @@ export interface ToolConfiguration {
   allowProtocols?: string[]
   denyProtocols?: string[]
   denyPools?: string[]
-  /** Flat form of `RouteOptions.liquiditySources.source` — see {@link LiquiditySources}. */
   liquiditySourcesSource?: string[]
-  /** Flat form of `RouteOptions.liquiditySources.destination` — see {@link LiquiditySources}. */
   liquiditySourcesDestination?: string[]
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -158,6 +158,10 @@ export interface RouteOptionsBase {
    *  Only supported by the `fly` exchange — see {@link PoolDeny}. */
   pools?: PoolDeny
 
+  /** Liquidity venues each swap leg may execute against, per side.
+   *  Only supported by the `fly` exchange — see {@link LiquiditySources}. */
+  liquiditySources?: LiquiditySources
+
   /** Timing strategies for the routes */
   timing?: Timing
 
@@ -311,6 +315,23 @@ export interface PoolDeny {
 }
 
 /**
+ * Liquidity venues a swap leg is allowed to execute against, scoped per side of
+ * the route. Names come from Fly's liquidity-source list and are chain-specific
+ * (e.g. `aerodrome-stable` on Base); a name valid on another chain simply yields
+ * no route. Venue-level filtering is only supported by the `fly` exchange
+ * aggregator, so a side with a list set is restricted to `fly`.
+ *
+ * On a same-chain route the single swap counts as the source leg, so `source`
+ * applies and `destination` is ignored.
+ */
+export interface LiquiditySources {
+  /** Venues allowed for the swap on the source chain. */
+  source?: string[]
+  /** Venues allowed for the swap on the destination chain. */
+  destination?: string[]
+}
+
+/**
  * @deprecated _InsuranceState is deprecated and will be removed in future versions.
  */
 export const _InsuranceState = [
@@ -449,6 +470,10 @@ export interface ToolConfiguration {
   allowProtocols?: string[]
   denyProtocols?: string[]
   denyPools?: string[]
+  /** Flat form of `RouteOptions.liquiditySources.source` — see {@link LiquiditySources}. */
+  liquiditySourcesSource?: string[]
+  /** Flat form of `RouteOptions.liquiditySources.destination` — see {@link LiquiditySources}. */
+  liquiditySourcesDestination?: string[]
 }
 
 export interface QuoteRequest extends ToolConfiguration, TimingStrings {


### PR DESCRIPTION
## Which Linear task is linked to this PR?

EXBE-580 (originating support ticket: TECHSUP-169).

## Why was it implemented this way?

Adds an optional per-side liquidity-venue allow-list to the routing options:

- `LiquiditySources` — `{ source?: string[], destination?: string[] }`, the venues each swap leg may execute against.
- `RouteOptionsBase.liquiditySources` — nested form, alongside the existing `pools`.
- `ToolConfiguration.liquiditySourcesSource` / `liquiditySourcesDestination` — flat form for the `/v1/quote` query surface.

Venue names come from Fly's liquidity-source list and are chain-specific (e.g. `aerodrome-stable` on Base). Venue-level filtering is Fly-only, so a side with a list set is reduced to `fly` — the same trade `pools.deny` already makes route-wide.

**Why per-side rather than route-wide.** The motivating case needs the destination-chain swap constrained to one venue while the source-chain swap stays unrestricted, and it has to work for a cross-chain swap into that chain as well as a same-chain swap on it. A single route-wide list (the `pools.deny` shape) can't express that, and `exchanges.allow` filters aggregators rather than venues.

**Why two shapes.** Mirrors `pools.deny` / `denyPools` exactly: `/v1/advanced/routes` takes nested options, the `/v1/quote` surfaces take flat query params. The nested interface carries the semantics; the flat keys `{@link}` to it rather than duplicating the docs.

**Why placed on `RouteOptionsBase`.** That is where `pools` lives, and it is the type the backend's presets and integrator `routeOptionOverwrites` config are declared against — so the parameter is settable per-integrator from config, not only per-request.

**Why `string[]` and not an enum.** Fly publishes 811 venue names and is the only authority on which are valid on a given chain. Enumerating them here would go stale and would move rejection from Fly (which can tell "unknown name" from "not on this chain") to us (which cannot). Deliberately left as opaque strings; the backend forwards them unchecked and maps Fly's rejection.

Additive and optional only — no existing field changes shape, so this is a minor release.

## Visual showcase (Screenshots or Videos)

Not applicable — type definitions only.

## Checklist before requesting a review

- [x] I have performed a self-review and testing of my code.
- [x] This pull request is focused and addresses a single problem.
- [ ] If this PR modifies the Types API or adds new features that require documentation, I have updated the documentation in the [public-docs](https://github.com/lifinance/public-docs) repository.

`pnpm build` (cjs/esm/declarations), eslint and prettier all clean; the four eslint warnings on `src/api.ts` are pre-existing and outside the changed ranges.

public-docs is **not** yet updated — the parameters need documenting on the quote/routes reference once the backend behaviour lands. Tracking that with the backend PR rather than here, since the user-facing description depends on the final validation and error semantics.

---

Consumed by lifi-backend `exbe-580` (PR to follow). Suggest publishing a beta from this branch for the backend CI to build against, and holding merge until the backend PR is approved — then cutting the official release and bumping the backend catalog to it.
